### PR TITLE
This is the right order to load the components 

### DIFF
--- a/extensible.jsb2
+++ b/extensible.jsb2
@@ -51,10 +51,10 @@
             "text": "DayDropZone.js",
             "path": "src/calendar/dd/"
         },{
-            "text": "EventStore.js",
+            "text": "EventModel.js",
             "path": "src/calendar/data/"
         },{
-            "text": "EventModel.js",
+            "text": "EventStore.js",
             "path": "src/calendar/data/"
         },{
             "text": "CalendarModel.js",


### PR DESCRIPTION
This is the right order to loda the components because the EventStore require EventModel
then if it's not in this order ext4.07 have this error: uncaught exception: Ext.Loader is not enabled, so dependencies cannot be resolved dynamically. Missing required class: Extensible.calendar.data.EventModel

this fix a bug submitted in the form: 
http://ext.ensible.com/forum/viewtopic.php?f=3&t=424
