### PR TITLE
Use right key name when searching object ids

### DIFF
--- a/src/calendar/view/AbstractCalendar.js
+++ b/src/calendar/view/AbstractCalendar.js
@@ -1115,9 +1115,10 @@ viewConfig: {
     // private
     isEventVisible : function(evt){
         var M = Extensible.calendar.data.EventMappings,
+            CM = Extensible.calendar.data.CalendarMappings,
             data = evt.data || evt,
             calRec = this.calendarStore ? 
-                this.calendarStore.findRecord(M.CalendarId.name, evt[M.CalendarId.name]) : null;
+                this.calendarStore.findRecord(CM.CalendarId.name, evt[M.CalendarId.name]) : null;
             
         if(calRec && calRec.data[Extensible.calendar.data.CalendarMappings.IsHidden.name] === true){
             // if the event is on a hidden calendar then no need to test the date boundaries


### PR DESCRIPTION
When searching calendars by id, you should use id mapping from calendar obj, not calendar id mapping from event object.

Otherwise you're forced to have calendar object id property named === event calendar id property.

For example without this patch you cannot name Event mapper CalendarId "calendar_id" and Calendar mapper CalendarId "id" , but they must be the same.

Using ORM systems Calendar/Events relation is a has_many, and is quite common to have Event.calendar_id which refers to Calendar.id, that's why the patch

(And if you want to use the ext hasmany relationships, this is the way to go...)
