### PR TITLE
Fixed bug when recurring events are made non-recurring

### DIFF
--- a/src/calendar/form/EventDetails.js
+++ b/src/calendar/form/EventDetails.js
@@ -376,9 +376,10 @@ Ext.define('Extensible.calendar.form.EventDetails', {
             me.fireEvent('eventadd', me, me.activeRecord);
         }
         else {
-            if (originalHasRecurrence) {
-                // We only need to prompt when editing an existing recurring event. If a normal
-                // event is edited to make it recurring just do a standard update.
+            if (originalHasRecurrence && me.activeRecord.isRecurring()) {
+                // We only need to prompt when editing an event that was recurring before being edited and is
+                // still recurring after being edited. If a normal event is edited to make it recurring or a
+                // recurring event is edited to make it normal just do a standard update.
                 me.onRecurrenceUpdate();
             }
             else {

--- a/src/calendar/form/EventWindow.js
+++ b/src/calendar/form/EventWindow.js
@@ -440,9 +440,10 @@ Ext.define('Extensible.calendar.form.EventWindow', {
             me.fireEvent('eventadd', me, me.activeRecord, me.animateTarget);
         }
         else {
-            if (originalHasRecurrence) {
-                // We only need to prompt when editing an existing recurring event. If a normal
-                // event is edited to make it recurring just do a standard update.
+            if (originalHasRecurrence && me.activeRecord.isRecurring()) {
+                // We only need to prompt when editing an event that was recurring before being edited and is
+                // still recurring after being edited. If a normal event is edited to make it recurring or a
+                // recurring event is edited to make it normal just do a standard update.
                 me.onRecurrenceUpdate();
             }
             else {

--- a/src/calendar/view/AbstractCalendar.js
+++ b/src/calendar/view/AbstractCalendar.js
@@ -976,7 +976,9 @@ viewConfig: {
      */
     storeReloadRequired: function(action, operation) {
         // This is the default logic for all actions
-        return operation.records[0].isRecurring();
+        // Refresh if the event is recurring or was recurring before being edited.
+        return operation.records[0].isRecurring() ||
+            operation.records[0].get(Extensible.calendar.data.EventMappings.RInstanceStartDate.name) ? true : false;
     },
 
     // private


### PR DESCRIPTION
Turning a recurring event into a non-recurrent did not trigger a refresh of the view. This left the calendar view in a inconsistent state. Implemented a fix that ensures that the view is refreshed in this situation.
