### PR TITLE
Fix bug in Extensible.form.recurrence.option.Weekly

### DIFF
--- a/src/form/recurrence/option/Weekly.js
+++ b/src/form/recurrence/option/Weekly.js
@@ -123,8 +123,9 @@ Ext.define('Extensible.form.recurrence.option.Weekly', {
         if (!me.preSetValue(v, me.daysCheckboxGroup)) {
             return me;
         }
+        // Clear all checkboxes
+        me.daysCheckboxGroup.setValue(null);
         if (!v) {
-            me.daysCheckboxGroup.setValue(null);
             return me;
         }
         var options = Ext.isArray(v) ? v : v.split(me.optionDelimiter),


### PR DESCRIPTION
Extensible.form.recurrence.option.Weekly did not properly initialize the seven checkboxes in some case.

To reproduce bug: Create a weekly event A without selecting any checkboxes. Create a weekly event B with selecting multiple checkboxes. Open event B in details view. Then close and open event A in details view. The checkboxes will be set wrong.

To fix, initialize checkboxes each time when widget displayed.
