### PR TITLE
Bug refresh views for recurring events

### DIFF
--- a/src/calendar/form/EventDetails.js
+++ b/src/calendar/form/EventDetails.js
@@ -376,9 +376,10 @@ Ext.define('Extensible.calendar.form.EventDetails', {
             me.fireEvent('eventadd', me, me.activeRecord);
         }
         else {
-            if (originalHasRecurrence) {
-                // We only need to prompt when editing an existing recurring event. If a normal
-                // event is edited to make it recurring just do a standard update.
+            if (originalHasRecurrence && me.activeRecord.isRecurring()) {
+                // We only need to prompt when editing an event that was recurring before being edited and is
+                // still recurring after being edited. If a normal event is edited to make it recurring or a
+                // recurring event is edited to make it normal just do a standard update.
                 me.onRecurrenceUpdate();
             }
             else {

--- a/src/calendar/form/EventWindow.js
+++ b/src/calendar/form/EventWindow.js
@@ -440,9 +440,10 @@ Ext.define('Extensible.calendar.form.EventWindow', {
             me.fireEvent('eventadd', me, me.activeRecord, me.animateTarget);
         }
         else {
-            if (originalHasRecurrence) {
-                // We only need to prompt when editing an existing recurring event. If a normal
-                // event is edited to make it recurring just do a standard update.
+            if (originalHasRecurrence && me.activeRecord.isRecurring()) {
+                // We only need to prompt when editing an event that was recurring before being edited and is
+                // still recurring after being edited. If a normal event is edited to make it recurring or a
+                // recurring event is edited to make it normal just do a standard update.
                 me.onRecurrenceUpdate();
             }
             else {

--- a/src/calendar/view/AbstractCalendar.js
+++ b/src/calendar/view/AbstractCalendar.js
@@ -969,17 +969,23 @@ viewConfig: {
     },
 
     /**
-     * Refresh the view. Determine whether a store reload is required after a given CRUD operation. A store reload
-     * is required if the changed event is recurring.
+     * Refresh the view. Determine if a store reload is required after a given CRUD operation.
      * @param {String} action One of 'create', 'update' or 'delete'
      * @param {Ext.data.Operation} operation The affected operation
      */
     refreshAfterEventChange: function(action, operation) {
-        var reload = operation.records[0].isRecurring() && !operation.wasStoreReloadTriggered;
+        // Determine if a store reload is needed. A store reload is needed if the event is recurring after being
+        // edited or was recurring before being edited AND a event store reload has not been triggered already for
+        // this operation.
+        // The term operation.records[0].get(Extensible.calendar.data.EventMappings.RInstanceStartDate.name)) is
+        // used to determine of an event was recurring before being edited.
+        var reload = (operation.records[0].isRecurring() ||
+            operation.records[0].get(Extensible.calendar.data.EventMappings.RInstanceStartDate.name)) &&
+            !operation.wasStoreReloadTriggered;
 
-        // For calendar views with a body and a header component (e.g. weekly view, day view), this function is
-        // called twice. Ensure that a store reload happens only once for the same operation.
         if (reload) {
+            // For calendar views with a body and a header component (e.g. weekly view, day view), this function is
+            // called twice. Ensure that a store reload is triggered only once for the same operation.
             operation.wasStoreReloadTriggered = true;
         }
         this.refresh(reload);


### PR DESCRIPTION
Hi Brian
This PR fixes three important issues related to refreshing calendar views after a recurring event has been edited. I am not sure if I have found the best possible ways to fix them but at least you should be able to get a good picture of what the issues are. Let me know if anything is not clear.

1) When a recurring event was turned non-recurrent, the event store was not reloaded, leading to an inconsistency view.

2) After editing recurrent events, the event store was reloaded up to 4 times. To reproduce: Start example application "Recurrence Demo". Go to monthly view, then to daily view, then to weekly view. Edit an existing recurring event by changing the title text. Save change. There will be four event store reloads.

This was caused be weekly view header, weekly view body, daily view header and daily view body each triggering a event store reload. Fixed this in new function refreshAfterEventChange() of AbstractCalendar. A flag is used to remember if a store reload was triggered for an event operation.

3) Weekly calendar view and daily calendar view are refreshed even if they are hidden. Fixed this in functions onUpdate(), onAdd() and onRemove() of AbstractCalendar. For calendar views that are composed of header and body, the hidden status must be checked with the owner of the current component.
