### PR TITLE
Fixed bug with creating and updating recurring events in daily view.

### DIFF
--- a/examples/calendar/remote/php/app/models/event.php
+++ b/examples/calendar/remote/php/app/models/event.php
@@ -114,8 +114,11 @@ class Event extends Model {
         $rec->save();
         
         if (isset($rec->attributes[Event::$rrule]) && $rec->attributes[Event::$rrule] != '') {
-            $recs = self::generateInstances($rec->attributes, $_SESSION[$GLOBALS['app_id']]['startDate'],
-                $_SESSION[$GLOBALS['app_id']]['endDate']);
+            $startDate = $_SESSION[$GLOBALS['app_id']]['startDate'];
+            $endDate = new DateTime($_SESSION[$GLOBALS['app_id']]['endDate']);
+            $endDate->modify('+1 day');
+            $endDate = $endDate->format('c');
+            $recs = self::generateInstances($rec->attributes, $startDate, $endDate);
         }
         else {
             $recs = array($rec->attributes);
@@ -256,7 +259,11 @@ class Event extends Model {
         }
         
         if ($rec->attributes[Event::$rrule]) {
-            $recs = self::generateInstances($rec->attributes, $_SESSION[$GLOBALS['app_id']]['startDate'], $_SESSION[$GLOBALS['app_id']]['endDate']);
+            $startDate = $_SESSION[$GLOBALS['app_id']]['startDate'];
+            $endDate = new DateTime($_SESSION[$GLOBALS['app_id']]['endDate']);
+            $endDate->modify('+1 day');
+            $endDate = $endDate->format('c');
+            $recs = self::generateInstances($rec->attributes, $startDate, $endDate);
         }
         else {
             $recs = array($rec->attributes);


### PR DESCRIPTION
In daily calendar view the creation or update of a recurrent event led to a server error message "Failed to update record". This was cause by the view start time and the view end time being set to the same time. 
