### PR TITLE
[OPEN-342] Bug with single-click - reproducible in 1.5.1

### DIFF
--- a/src/calendar/view/AbstractCalendar.js
+++ b/src/calendar/view/AbstractCalendar.js
@@ -2072,11 +2072,6 @@ Ext.override(Extensible.calendar.view.AbstractCalendar, {
         if (me.dropZone) {
             me.dropZone.clearShims();
         }
-        if (me.menuActive === true) {
-            // ignore the first click if a context menu is active (let it close)
-            me.menuActive = false;
-            return true;
-        }
         if (el) {
             var id = me.getEventIdFromEl(el),
                 rec = me.getEventRecord(id);


### PR DESCRIPTION
[OPEN-342] Bug with single-click - reproducible in 1.5.1
as posted in the forum at:
http://ext.ensible.com/forum/viewtopic.php?f=3&t=634

The fix is removal of few lines of code (to not to ignore the onClick event). Have tested with the following 2 scenarios:
1) Right click on a event -> the menu items show up
    Move the mouse to another day and click. 'Add Event' form comes up.
2) Right click on an event -> the menu items show up
    click on an existing event. 'Event details' form is displayed.

No known side effects were noticed.
