### PR TITLE
CalendarListPanel does not display properly under IE9

### DIFF
--- a/resources/css/calendar.css
+++ b/resources/css/calendar.css
@@ -920,6 +920,7 @@ td.ext-cal-dtitle-today div {
     position: relative;
     margin-bottom: 2px;
     cursor: pointer;
+    list-style-type: none;
 }
 .x-calendar-list li em {
     background-image: url(../images/default/calendar-sprites.gif);


### PR DESCRIPTION
Class CalendarListPanel.js does not display properly under IE9 and IE8. Calendar entries are shown in double height. See forum http://ext.ensible.com/forum/viewtopic.php?f=3&t=766
