### PR TITLE
Fix context menu events being fired with undefined parameter.

### DIFF
--- a/src/calendar/menu/Event.js
+++ b/src/calendar/menu/Event.js
@@ -220,6 +220,5 @@ Ext.define('Extensible.calendar.menu.Event', {
     // private
     onHide: function() {
         this.callParent(arguments);
-        delete this.ctxEl;
     }
 });


### PR DESCRIPTION
Class Extensible.calendar.menu.Event support events "eventdetails" and "eventdelete". These two events are fired with an undefined third parameter. See lines 165 and 172. This is caused by instance variable ctxEl being deleted in the onHide() function. In my understanding, the delete statement can simply be removed.
