### PR TITLE
don't set programatically changed fields as dirty

### DIFF
--- a/src/form/field/DateRange.js
+++ b/src/form/field/DateRange.js
@@ -268,9 +268,13 @@ Ext.define('Extensible.form.field.DateRange', {
 
         if(startValue > endValue) {
             if(startend === 'start') {
+                var wasDirty = endField.isDirty();
                 endField.setValue(startValue);
+                if (!wasDirty) endField.resetOriginalValue()
             }else{
+                var wasDirty = startField.isDirty();
                 startField.setValue(endValue);
+                if (!wasDirty) startField.resetOriginalValue()
                 me.checkDates(type, 'start');
             }
         }
@@ -382,7 +386,11 @@ Ext.define('Extensible.form.field.DateRange', {
         }
         return dirty;
     },
-    
+
+    resetOriginalValue: function() {
+        this.delegateFn('resetOriginalValue');
+    },
+
     /**
      * @protected 
      */


### PR DESCRIPTION
that allows futher programatically adjustment of values while they are unchanged by the user.
Also forward resetOriginalValue call to fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bmoeskau/extensible/70)
<!-- Reviewable:end -->
