### PR TITLE
Pass event row (in addition to data) to getTemplateEventData method

### DIFF
--- a/src/calendar/view/DayBody.js
+++ b/src/calendar/view/DayBody.js
@@ -333,7 +333,7 @@ Ext.define('Extensible.calendar.view.DayBody', {
         return this.eventAllDayTpl;
     },
 
-    getTemplateEventData: function(evtData) {
+    getTemplateEventData: function(evtData, evt) {
         var M = Extensible.calendar.data.EventMappings,
             extraClasses = [this.getEventSelectorCls(evtData[M.EventId.name])],
             data = {},
@@ -358,8 +358,7 @@ Ext.define('Extensible.calendar.view.DayBody', {
         extraClasses.push('ext-evt-block');
 
         if(this.getEventClass) {
-            rec = this.getEventRecord(evtData[M.EventId.name]);
-            var cls = this.getEventClass(rec, !!evtData._renderAsAllDay, data, this.store);
+            var cls = this.getEventClass(evt, !!evtData._renderAsAllDay, data, this.store);
             extraClasses.push(cls);
         }
 
@@ -437,7 +436,7 @@ Ext.define('Extensible.calendar.view.DayBody', {
                     _positioned: true
                 });
                 evts.push({
-                    data: this.getTemplateEventData(item),
+                    data: this.getTemplateEventData(item, evt),
                     date: Extensible.Date.add(this.viewStart, {days: day})
                 });
             }

--- a/src/calendar/view/MonthDayDetail.js
+++ b/src/calendar/view/MonthDayDetail.js
@@ -98,15 +98,15 @@ Ext.define('Extensible.calendar.view.MonthDayDetail', {
             item.spanCls = (item.spanLeft ? (item.spanRight ? 'ext-cal-ev-spanboth' :
                 'ext-cal-ev-spanleft') : (item.spanRight ? 'ext-cal-ev-spanright' : ''));
 
-            templateData.push({markup: eventTpl.apply(this.getTemplateEventData(item))});
+            templateData.push({markup: eventTpl.apply(this.getTemplateEventData(item, evt))});
         }, this);
         
         this.tpl.overwrite(this.el, templateData);
         this.fireEvent('eventsrendered', this, this.date, evts.getCount());
     },
     
-    getTemplateEventData: function(evtData) {
-        var data = this.view.getTemplateEventData(evtData);
+    getTemplateEventData: function(evtData, evt) {
+        var data = this.view.getTemplateEventData(evtData, evt);
         data._elId = 'dtl-'+data._elId;
         return data;
     }


### PR DESCRIPTION
This allows accessing model methods.
And this fixes a bug when copying event where the row was not passed to getEventClass as it wasn't found in the store.