### PR TITLE
Cleanup dirty record when editor window is closed with close tool in panel header

### DIFF
--- a/src/calendar/form/EventWindow.js
+++ b/src/calendar/form/EventWindow.js
@@ -66,6 +66,7 @@ Ext.define('Extensible.calendar.form.EventWindow', {
 
     // General configs
     closeAction: 'hide',
+    closable: false,
     modal: false,
     resizable: false,
     constrain: true,
@@ -77,7 +78,18 @@ Ext.define('Extensible.calendar.form.EventWindow', {
     formPanelConfig: {
         border: false
     },
-    
+
+    /**
+     * Add close tool to panel header. When closing the editor it is important to cleanup the record if dirty.
+     * Handle it the same way as the cancel button.
+     */
+    tools: [{
+        type:'close',
+        handler: function(evt, el, header){
+            header.ownerCt.onCancel();
+        }
+    }],
+
     /**
      * @cfg {Boolean} allowDefaultAdd
      * @since 1.6.0


### PR DESCRIPTION
When an event record is edited in EventWindow and the server rejects to save the record, the store contains a dirty record. If the user then clicks the cancel button, a cleanup is triggered that will remove the dirty event record from the store. If instead the user click the close tool (in panel header), no cleanup is performed and the calendar shows inconsistent information. This PR ensure that the store cleanup is performed when the user abort editing with the close button.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bmoeskau/extensible/74)
<!-- Reviewable:end -->
