### PR TITLE
Fixed error handling after an event copy operation is rejected by the server

### DIFF
--- a/src/calendar/view/AbstractCalendar.js
+++ b/src/calendar/view/AbstractCalendar.js
@@ -1558,7 +1558,7 @@ Ext.define('Extensible.calendar.view.AbstractCalendar', {
         Ext.each(operation.records, function(rec) {
             if (rec.dirty) {
                 if (rec.phantom) {
-                    rec.unjoin(this.eventStore);
+                    this.store.remove(rec);
                 }
                 else {
                     rec.reject();


### PR DESCRIPTION
If an event is copied and the server rejects to persist the copied event, then the event store is not cleaned up. The copied but rejected event is not removed from the event store and this leads to an inconsistent calendar view, i.e. the calendar view shows an event that does not exist on the server side. This fix ensures that copied but rejected events are remove from the store. 
If an event is moved instead of copied, then the store cleanup works properly.