### PR TITLE
save state of calendars after refresh

### DIFF
--- a/examples/calendar/TestApp/App.js
+++ b/examples/calendar/TestApp/App.js
@@ -40,7 +40,11 @@ Ext.define('Extensible.example.calendar.TestApp.App', {
             // of MemoryEventStore to see how automatic store messaging is implemented.
             autoMsg: false
         });
-        
+
+        // Make the calendar stateful. This is optional. If set, the application will remember hidden
+        // calendars in the calendar list panel.
+        Ext.state.Manager.setProvider(new Ext.state.CookieProvider());
+
         // This is the app UI layout code.  All of the calendar views are subcomponents of
         // CalendarPanel, but the app title bar and sidebar/navigation calendar are separate
         // pieces that are composed in app-specific layout code since they could be omitted


### PR DESCRIPTION
Remember the state of hidden and displayed calendars.
Note that this works only, if a persistence provider has been passed to the state manager. Ext.state.Manager.setProvider(new Ext.state.CookieProvider());

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bmoeskau/extensible/82)
<!-- Reviewable:end -->
