### PR TITLE
Added missing exists() checks to language strings of recurrence widgets.

### DIFF
--- a/src/locale/extensible-lang-de.js
+++ b/src/locale/extensible-lang-de.js
@@ -276,13 +276,13 @@ Ext.onReady(function() {
         });
     }
 
-    if (Extensible.form.recurrence.FrequencyCombo) {
+    if (exists('Extensible.form.recurrence.FrequencyCombo')) {
         Ext.apply(Extensible.form.recurrence.FrequencyCombo.prototype, {
             fieldLabel: 'Wiederholen'
         });
     }
 
-    if (Extensible.form.recurrence.RangeEditWindow) {
+    if (exists('Extensible.form.recurrence.RangeEditWindow')) {
         Ext.apply(Extensible.form.recurrence.RangeEditWindow.prototype, {
             title: 'Wiederkehrender Termin',
             saveButtonText: 'Speichern',
@@ -290,7 +290,7 @@ Ext.onReady(function() {
         });
     }
 
-    if (Extensible.form.recurrence.RangeEditPanel) {
+    if (exists('Extensible.form.recurrence.RangeEditPanel')) {
         Ext.apply(Extensible.form.recurrence.RangeEditPanel.prototype, {
             headerText: 'Auf welche Termine dieser Termin-Serie möchten Sie Ihre Änderungen anwenden?',
             optionSingleButtonText: 'Nur diesen',
@@ -302,7 +302,7 @@ Ext.onReady(function() {
         });
     }
 
-    if (Extensible.form.recurrence.option.Interval) {
+    if (exists('Extensible.form.recurrence.option.Interval')) {
         Ext.apply(Extensible.form.recurrence.option.Interval.prototype, {
             dateLabelFormat: 'l, j. F',
             strings: {
@@ -320,7 +320,7 @@ Ext.onReady(function() {
         });
     }
 
-    if (Extensible.form.recurrence.option.Duration) {
+    if (exists('Extensible.form.recurrence.option.Duration')) {
         Ext.apply(Extensible.form.recurrence.option.Duration.prototype, {
             strings: {
                 andContinuing: 'und endet',
@@ -332,7 +332,7 @@ Ext.onReady(function() {
         });
     }
 
-    if (Extensible.form.recurrence.option.Weekly) {
+    if (exists('Extensible.form.recurrence.option.Weekly')) {
         Ext.apply(Extensible.form.recurrence.option.Weekly.prototype, {
             strings: {
                 on: 'am'
@@ -340,7 +340,7 @@ Ext.onReady(function() {
         });
     }
 
-    if (Extensible.form.recurrence.option.Monthly) {
+    if (exists('Extensible.form.recurrence.option.Monthly')) {
         Ext.apply(Extensible.form.recurrence.option.Monthly.prototype, {
             strings: {
                 // E.g. "on the 15th day of each month/year"

--- a/src/locale/extensible-lang-en_GB.js
+++ b/src/locale/extensible-lang-en_GB.js
@@ -277,13 +277,13 @@ Ext.onReady(function() {
         });
     }
 
-    if (Extensible.form.recurrence.FrequencyCombo) {
+    if (exists('Extensible.form.recurrence.FrequencyCombo')) {
         Ext.apply(Extensible.form.recurrence.FrequencyCombo.prototype, {
             fieldLabel: 'Repeats'
         });
     }
 
-    if (Extensible.form.recurrence.RangeEditWindow) {
+    if (exists('Extensible.form.recurrence.RangeEditWindow')) {
         Ext.apply(Extensible.form.recurrence.RangeEditWindow.prototype, {
             title: 'Recurring Event Options',
             saveButtonText: 'Save',
@@ -291,7 +291,7 @@ Ext.onReady(function() {
         });
     }
 
-    if (Extensible.form.recurrence.RangeEditPanel) {
+    if (exists('Extensible.form.recurrence.RangeEditPanel')) {
         Ext.apply(Extensible.form.recurrence.RangeEditPanel.prototype, {
             headerText: 'There are multiple events in this series. How would you like your changes applied?',
             optionSingleButtonText: 'Single',
@@ -303,7 +303,7 @@ Ext.onReady(function() {
         });
     }
 
-    if (Extensible.form.recurrence.option.Interval) {
+    if (exists('Extensible.form.recurrence.option.Interval')) {
         Ext.apply(Extensible.form.recurrence.option.Interval.prototype, {
             dateLabelFormat: 'l, F j',
             strings: {
@@ -321,7 +321,7 @@ Ext.onReady(function() {
         });
     }
 
-    if (Extensible.form.recurrence.option.Duration) {
+    if (exists('Extensible.form.recurrence.option.Duration')) {
         Ext.apply(Extensible.form.recurrence.option.Duration.prototype, {
             strings: {
                 andContinuing: 'and continuing',
@@ -333,7 +333,7 @@ Ext.onReady(function() {
         });
     }
 
-    if (Extensible.form.recurrence.option.Weekly) {
+    if (exists('Extensible.form.recurrence.option.Weekly')) {
         Ext.apply(Extensible.form.recurrence.option.Weekly.prototype, {
             strings: {
                 on: 'on'
@@ -341,7 +341,7 @@ Ext.onReady(function() {
         });
     }
 
-    if (Extensible.form.recurrence.option.Monthly) {
+    if (exists('Extensible.form.recurrence.option.Monthly')) {
         Ext.apply(Extensible.form.recurrence.option.Monthly.prototype, {
             strings: {
                 // E.g. "on the 15th day of each month/year"


### PR DESCRIPTION
This change make the two language files consistent with the english language file. Without this fix, the language files don't load in dynamic mode. Should be safe to merge.